### PR TITLE
CLEARFACTS-12646: Add project version to SonarQube scan

### DIFF
--- a/.github/workflows/sonarqube.yml
+++ b/.github/workflows/sonarqube.yml
@@ -16,7 +16,8 @@ jobs:
         fetch-depth: 0
     - name: Resolve environment variables
       if: github.ref == 'refs/heads/master'
-      uses: Clearfacts/cf-actions/resolve-env-vars@8c77a730bab029799bbfa04a1ad76b1914a82fb0 # main
+      shell: bash
+      run: echo "BUILD_NUMBER=v${{ github.run_number }}" >> $GITHUB_ENV
     - name: SonarQube Scan
       uses: SonarSource/sonarqube-scan-action@v5.1.0 # Ex: v4.1.0, See the latest version at https://github.com/marketplace/actions/official-sonarqube-scan
       env:

--- a/.github/workflows/sonarqube.yml
+++ b/.github/workflows/sonarqube.yml
@@ -10,11 +10,18 @@ jobs:
   sonarqube:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-      - name: SonarQube Scan
-        uses: SonarSource/sonarqube-scan-action@v5.1.0
-        env:
-          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-          SONAR_HOST_URL: ${{ secrets.SONAR_HOST_URL }}
+    - uses: actions/checkout@v4
+      with:
+        # Disabling shallow clones is recommended for improving the relevancy of reporting
+        fetch-depth: 0
+    - name: Resolve environment variables
+      if: github.ref == 'refs/heads/master'
+      uses: Clearfacts/cf-actions/resolve-env-vars@8c77a730bab029799bbfa04a1ad76b1914a82fb0 # main
+    - name: SonarQube Scan
+      uses: SonarSource/sonarqube-scan-action@v5.1.0 # Ex: v4.1.0, See the latest version at https://github.com/marketplace/actions/official-sonarqube-scan
+      env:
+        SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+        SONAR_HOST_URL: ${{ secrets.SONAR_HOST_URL }}
+      with:
+        args: >
+          ${{ github.ref == 'refs/heads/master' && format('-Dsonar.projectVersion={0}', env.BUILD_NUMBER) || '' }}


### PR DESCRIPTION
## Summary
- Add resolve-env-vars step to resolve BUILD_NUMBER on the default branch
- Pass `-Dsonar.projectVersion` to the SonarQube scan so versions are tracked in SonarQube